### PR TITLE
Minor fix to correctly filter Cassandra nodes from bastion host

### DIFF
--- a/ds-collector/ds-collector
+++ b/ds-collector/ds-collector
@@ -147,7 +147,7 @@ list_cassandra_nodes() {
     ip_command="ip -4 a"
     command -v ip >/dev/null 2>&1 || ip_command="ifconfig"
     for ip in ${cassandraNodes} ; do
-      ${ip_command} | grep -q '${ip}/' && { echo >&2 "The ds-collector script cannot be executed from a Cassandra/DSE node. Please execute the script from a jumpbox/bastion server that has access to all nodes to the data-center/cluster."; exit 1; }
+      ${ip_command} | grep -q '${ip}[/ ]' && { echo >&2 "The ds-collector script cannot be executed from a Cassandra/DSE node. Please execute the script from a jumpbox/bastion server that has access to all nodes to the data-center/cluster."; exit 1; }
     done
 
     # more accurate disk space check

--- a/ds-collector/ds-collector
+++ b/ds-collector/ds-collector
@@ -147,7 +147,7 @@ list_cassandra_nodes() {
     ip_command="ip -4 a"
     command -v ip >/dev/null 2>&1 || ip_command="ifconfig"
     for ip in ${cassandraNodes} ; do
-      ${ip_command} | grep -q $ip && { echo >&2 "The ds-collector script cannot be executed from a Cassandra/DSE node. Please execute the script from a jumpbox/bastion server that has access to all nodes to the data-center/cluster."; exit 1; }
+      ${ip_command} | grep -q '${ip}/' && { echo >&2 "The ds-collector script cannot be executed from a Cassandra/DSE node. Please execute the script from a jumpbox/bastion server that has access to all nodes to the data-center/cluster."; exit 1; }
     done
 
     # more accurate disk space check
@@ -1143,4 +1143,3 @@ elif [ "$uploadMode" ]; then
 fi
 
 echo -e  \\n"exiting...mode required!"; halp; exit 2
-


### PR DESCRIPTION
Currently when a running the discovery phase the script checks for Cassandra nodes and exits if detects a match:
https://github.com/datastax/diagnostic-collection/blob/744e043562abfc145aa2e9fb4642209e2778c8c0/ds-collector/ds-collector#L147-L151

Say, for example, you have a 15 Cassandra node cluster, with IPs:
```
192.168.0.1/24
...
192.168.0.15/24
```

And your bastion host has the IP `192.168.0.100`

When running the above check, the bastion IP of `192.168.0.100` would be a match with Cassandra node `192.168.0.10` and thus the script errors out.

This patch fixes that.

