### PR TITLE
Avoid clashes between sed and AWS secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ collector: check-env generate-key
 ifdef COLLECTOR_S3_AWS_KEY
 ifdef COLLECTOR_S3_AWS_SECRET
 	@sed -i.bak 's/\#keyId=.*/keyId=\"${COLLECTOR_S3_AWS_KEY}\"/' collector/collector.conf
-	@sed -i.bak 's/\#keySecret=.*/keySecret=\"${COLLECTOR_S3_AWS_SECRET}\"/' collector/collector.conf
+	@sed -i.bak 's|\#keySecret=.*|keySecret=\"${COLLECTOR_S3_AWS_SECRET}\"|' collector/collector.conf
 	@sed -i.bak 's/skipS3=.*/skipS3=\"false\"/' collector/collector.conf
 endif
 endif


### PR DESCRIPTION
The AWS secrets are strings of numbers, characters and two special characters: `/` and `+`.
This opens the possibility for a clash with the sed command we have in the Makefile.
In testing scenarios, when a new secrets gets generated for each run, it's very likely to have a `/` in there, which then breaks the sed.
Fortunately, sed is flexible and allows other command delimiters.