### PR TITLE
In gha, update ubuntu repositories before installing packages

### DIFF
--- a/.github/workflows/ds-collector-ci.yml
+++ b/.github/workflows/ds-collector-ci.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Test ds-collector
       working-directory: ds-collector-tests
       run: |
+        sudo apt-get update
         sudo apt-get install -y  binfmt-support qemu-user qemu-user-static
         sudo curl -L "https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
         sudo chmod uga+x /usr/local/bin/docker-compose
@@ -45,6 +46,7 @@ jobs:
 #   - name: Test ds-collector
 #     working-directory: ds-collector-tests
 #     run: |
+#        sudo apt-get update
 #       sudo apt-get install -y  binfmt-support qemu-user qemu-user-static
 #       sudo curl -L "https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 #       sudo chmod uga+x /usr/local/bin/docker-compose
@@ -64,6 +66,7 @@ jobs:
     - name: Test ds-collector
       working-directory: ds-collector-tests
       run: |
+        sudo apt-get update
         sudo apt-get install -y  binfmt-support qemu-user qemu-user-static
         echo "Testing ds-collector"
         make -f cluster-vanilla-k8s.make
@@ -81,6 +84,7 @@ jobs:
     - name: Test ds-collector
       working-directory: ds-collector-tests
       run: |
+        sudo apt-get update
         sudo apt-get install -y  binfmt-support qemu-user qemu-user-static
         echo "Testing ds-collector"
         make -f cluster-dse-k8s.make


### PR DESCRIPTION
fix gha.
see failure in https://github.com/datastax/diagnostic-collection/actions/runs/17788419472 

`apt-get install -y  binfmt-support qemu-user qemu-user-static` stopped working as packages couldn't be found in the repositories as-is.  Updating repositories before trying to install them fixes it.